### PR TITLE
Add basic tests and lint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install backend deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+
+      - name: Python lint
+        run: ruff check backend --exit-zero
+
+      - name: Backend tests
+        run: |
+          cd backend
+          pytest
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'yarn'
+          cache-dependency-path: frontend/yarn.lock
+
+      - name: Install frontend deps
+        run: |
+          cd frontend
+          corepack enable
+          yarn install --immutable
+
+      - name: ESLint
+        run: |
+          cd frontend
+          yarn lint
+
+      - name: Frontend tests
+        run: |
+          cd frontend
+          yarn test --run

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,3 +8,10 @@ dependencies = [
     "fastapi>=0.115.8",
     "uvicorn>=0.34.0",
 ]
+
+[tool.pytest.ini_options]
+addopts = "-vv"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 120

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,6 @@ openai
 beautifulsoup4
 requests
 supabase
+pytest
+ruff
+

--- a/backend/tests/test_ai_coach_messages.py
+++ b/backend/tests/test_ai_coach_messages.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+def test_get_ai_coach_messages():
+    response = client.get('/routes/ai-coach-messages/')
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 3

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["react", "@typescript-eslint"],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "vitest",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -371,7 +372,12 @@
     "vite": "4.4.5",
     "vite-tsconfig-paths": "4.2.2",
     "@vitejs/plugin-react": "^4.0.0",
-    "@firebase/app": "^0.11.1"
+    "@firebase/app": "^0.11.1",
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.0.0"
+    "@typescript-eslint/eslint-plugin": "^7.4.0",
+    "@typescript-eslint/parser": "^7.4.0"
   },
   "packageManager": "yarn@4.0.2",
   "nodeLinker": "pnpm"

--- a/frontend/src/AppWrapper.test.tsx
+++ b/frontend/src/AppWrapper.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { AppWrapper } from './AppWrapper'
+
+describe('AppWrapper', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<AppWrapper />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    environment: 'jsdom',
+  },
+})


### PR DESCRIPTION
## Summary
- add pytest config and sample FastAPI test
- configure Vitest with a sample React test
- add ESLint configuration
- include test and lint dependencies
- run lint and tests in CI

## Testing
- `pytest backend/tests/test_ai_coach_messages.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6843f0f8f5608323a29fa84130772a70