### PR TITLE
Add AI coach message endpoint

### DIFF
--- a/docs/integration-plan.md
+++ b/docs/integration-plan.md
@@ -1,0 +1,28 @@
+# Integration Plan for AI Features
+
+This document outlines how AI-driven features integrate with the existing backend.
+
+## Current Status
+- The backend exposes `/routes/ai-coach-messages/` returning mock `AICoachMessage` data.
+- The frontend expects a method `brain.get_ai_coach_messages()` to consume this endpoint.
+
+## Next Steps
+1. **User Tracking**
+   - Store user activity events (e.g., page views, workouts) in a new Supabase table `user_tracking`.
+   - Add backend endpoints for recording events and retrieving aggregates.
+   - Use Supabase row level security tied to the authenticated user.
+
+2. **Recommendations**
+   - Implement a service that analyzes health data and user tracking events to generate message records in `ai_coach_messages`.
+   - Schedule periodic jobs to compute new recommendations using Python tasks.
+   - Expose an endpoint to fetch unread recommendations for the dashboard.
+
+3. **Dashboards**
+   - Extend existing dashboard pages to call the new endpoints via the `brain` client.
+   - Visualize metrics (sleep, HRV, steps) alongside AI coach messages and recommendations.
+   - Provide filters for time range and message types.
+
+## End-to-End Flow
+1. Frontend calls `brain.get_ai_coach_messages()`.
+2. Backend returns messages for the authenticated user.
+3. Future iterations will enrich this flow with real data from Supabase and tracking events.

--- a/frontend/src/brain/Brain.ts
+++ b/frontend/src/brain/Brain.ts
@@ -1,4 +1,4 @@
-import { HandleHealthzData } from "./data-contracts";
+import { HandleHealthzData, AICoachMessageResponse } from "./data-contracts";
 import { HttpClient, RequestParams } from "./http-client";
 
 export class Brain<SecurityDataType = unknown> extends HttpClient<SecurityDataType> {
@@ -12,6 +12,20 @@ export class Brain<SecurityDataType = unknown> extends HttpClient<SecurityDataTy
   handle_healthz = (params: RequestParams = {}) =>
     this.request<HandleHealthzData, any>({
       path: `/_healthz`,
+      method: "GET",
+      ...params,
+    });
+
+  /**
+   * Returns AI coach messages for the authenticated user
+   *
+   * @name get_ai_coach_messages
+   * @summary Get AI coach messages
+   * @request GET:/routes/ai-coach-messages/
+   */
+  get_ai_coach_messages = (params: RequestParams = {}) =>
+    this.request<AICoachMessageResponse[], any>({
+      path: `/routes/ai-coach-messages/`,
       method: "GET",
       ...params,
     });

--- a/frontend/src/brain/BrainRoute.ts
+++ b/frontend/src/brain/BrainRoute.ts
@@ -1,4 +1,4 @@
-import { HandleHealthzData } from "./data-contracts";
+import { HandleHealthzData, AICoachMessageResponse } from "./data-contracts";
 
 export namespace Brain {
   /**
@@ -13,5 +13,19 @@ export namespace Brain {
     export type RequestBody = never;
     export type RequestHeaders = {};
     export type ResponseBody = HandleHealthzData;
+  }
+
+  /**
+   * Get AI coach messages for the current user
+   * @name get_ai_coach_messages
+   * @summary Get AI coach messages
+   * @request GET:/routes/ai-coach-messages/
+   */
+  export namespace get_ai_coach_messages {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = AICoachMessageResponse[];
   }
 }

--- a/frontend/src/brain/data-contracts.ts
+++ b/frontend/src/brain/data-contracts.ts
@@ -1,1 +1,13 @@
 export type HandleHealthzData = any;
+
+export interface AICoachMessageResponse {
+  id: string;
+  user_id: string;
+  title?: string | null;
+  body: string;
+  message_type: string;
+  urgency: string;
+  deep_link?: string | null;
+  created_at: string;
+  read_at?: string | null;
+}


### PR DESCRIPTION
## Summary
- add `get_ai_coach_messages` client in Brain API
- document integration plan for user tracking and recommendations

## Testing
- `yarn tsc --noEmit` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6843f11637bc83239e6630cf2e3f93bd