### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'yarn'
+      - name: Install frontend dependencies
+        run: |
+          corepack enable
+          yarn --cwd frontend install --immutable
+      - name: Build frontend
+        run: yarn --cwd frontend build
+      - name: Install backend dependencies
+        run: |
+          python -m pip install -r backend/requirements.txt
+          python -m pip install pytest
+      - name: Run backend tests
+        run: |
+          cd backend
+          pytest -q


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running Python and Node steps

## Testing
- `pytest -q` *(fails: no tests ran)*
- `yarn --cwd frontend build --mode=production --silent` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6843f12955108323bf3847f213fdc25f