### PR TITLE
Fix backend venv path

### DIFF
--- a/backend/install.sh
+++ b/backend/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-uv venv
-source ./venv/bin/activate
+uv venv .venv
+source .venv/bin/activate
 uv pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- unify venv paths so install.sh and run.sh use `.venv`

## Testing
- `make install` *(fails: esbuild build error)*
- `make run-backend`

------
https://chatgpt.com/codex/tasks/task_e_6843f630f58c83239ef275a6c884e805