### PR TITLE
Improve router config handling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10,16 +10,30 @@ from databutton_app.mw.auth_mw import AuthConfig, get_authorized_user
 
 
 def get_router_config() -> dict:
+    """Return the router configuration or an empty dict if not found."""
+    config_path = pathlib.Path("routers.json")
+
+    if not config_path.exists():
+        # Missing config is not fatal; just return an empty configuration
+        return {}
+
     try:
-        # Note: This file is not available to the agent
-        cfg = json.loads(open("routers.json").read())
-    except:
+        with config_path.open() as f:
+            return json.load(f)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid router configuration: {exc}") from exc
+
+
+def is_auth_disabled(router_config: dict | None, name: str) -> bool:
+    """Return ``True`` if auth is disabled for the given router."""
+    if not isinstance(router_config, dict):
         return False
-    return cfg
 
-
-def is_auth_disabled(router_config: dict, name: str) -> bool:
-    return router_config["routers"][name]["disableAuth"]
+    return (
+        router_config.get("routers", {})
+        .get(name, {})
+        .get("disableAuth", False)
+    )
 
 
 def import_api_routers() -> APIRouter:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,60 @@
+import json
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+# Provide stub for databutton_app dependency so main.py can be imported
+sys.modules["databutton_app"] = types.ModuleType("databutton_app")
+sys.modules["databutton_app.mw"] = types.ModuleType("databutton_app.mw")
+stub = types.ModuleType("databutton_app.mw.auth_mw")
+stub.AuthConfig = object
+def _dummy():
+    pass
+stub.get_authorized_user = _dummy
+sys.modules["databutton_app.mw.auth_mw"] = stub
+
+# Dynamically import backend/main.py as module 'backend_main'
+MODULE_PATH = Path(__file__).resolve().parents[1] / "backend" / "main.py"
+spec = importlib.util.spec_from_file_location("backend_main", MODULE_PATH)
+backend_main = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(backend_main)
+
+
+def test_get_router_config_missing(monkeypatch):
+    # Simulate missing routers.json
+    def fake_exists(self):
+        return False
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    cfg = backend_main.get_router_config()
+    assert cfg == {}
+
+
+def test_get_router_config_invalid(monkeypatch):
+    data = "{invalid json"
+
+    def fake_exists(self):
+        return True
+
+    def fake_open(self, *args, **kwargs):
+        from io import StringIO
+
+        return StringIO(data)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(Path, "open", fake_open)
+    with pytest.raises(ValueError):
+        backend_main.get_router_config()
+
+
+def test_is_auth_disabled_missing():
+    assert backend_main.is_auth_disabled({}, "missing") is False
+
+
+def test_is_auth_disabled_valid():
+    cfg = {"routers": {"api": {"disableAuth": True}}}
+    assert backend_main.is_auth_disabled(cfg, "api") is True
+


### PR DESCRIPTION
## Summary
- handle missing router config file gracefully and raise on invalid JSON
- make `is_auth_disabled` robust against missing data
- add tests for router and auth helpers

## Testing
- `pip install fastapi==0.111.0`
- `pip install pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f638cf5483238127b658ee84dd84