### PR TITLE
Fetch AI coach messages from DB

### DIFF
--- a/backend/app/apis/ai_coach_messages_api/__init__.py
+++ b/backend/app/apis/ai_coach_messages_api/__init__.py
@@ -2,6 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from typing import List, Optional
 import datetime
+import databutton as db
+from supabase import create_client, Client
+from app.auth import AuthorizedUser
 
 # Import get_current_user_id if you have it defined in an accessible auth utility
 # For now, we'll mock it or assume it's passed if needed.
@@ -23,76 +26,29 @@ class AICoachMessageResponse(BaseModel):
     created_at: datetime.datetime
     read_at: Optional[datetime.datetime] = None
 
-# Mock user ID for now, replace with actual dependency later
-MOCK_USER_ID = "00000000-0000-0000-0000-000000000000" # Replace with a real UUID or use auth
 
 @router.get("/", response_model=List[AICoachMessageResponse])
 def get_ai_coach_messages(
-    # current_user_id: str = Depends(get_current_user_id) # Uncomment when auth is ready
+    unread_only: bool = False,
+    user: AuthorizedUser = Depends(),
 ) -> List[AICoachMessageResponse]:
-    """
-    Retrieves AI Coach messages for the authenticated user.
-    Currently returns mock data.
-    """
-    # In a real scenario, you'd fetch this from the ai_coach_messages table in Supabase
-    # based on the current_user_id.
-    
-    # current_user_id will be used here when auth is integrated
-    user_id_to_filter = MOCK_USER_ID # Replace with current_user_id
+    """Return AI Coach messages for the authenticated user."""
 
-    mock_messages = [
-        AICoachMessageResponse(
-            id="msg_001",
-            user_id=user_id_to_filter,
-            title="HRV Dip Detected",
-            body="We've noticed a significant dip in your HRV over the past 2 days. Consider prioritizing rest and recovery. A light walk or meditation could be beneficial.",
-            message_type="ALERT",
-            urgency="HIGH",
-            deep_link="/biometric-log-page?metric=hrv",
-            created_at=datetime.datetime.now() - datetime.timedelta(hours=2),
-            read_at=None
-        ),
-        AICoachMessageResponse(
-            id="msg_002",
-            user_id=user_id_to_filter,
-            title="Consistent Sleep Schedule",
-            body="Great job maintaining a consistent sleep schedule this week! This is key for recovery and cognitive function.",
-            message_type="PRAISE",
-            urgency="LOW",
-            created_at=datetime.datetime.now() - datetime.timedelta(days=1),
-            read_at=datetime.datetime.now() - datetime.timedelta(hours=5) # Example of a read message
-        ),
-        AICoachMessageResponse(
-            id="msg_003",
-            user_id=user_id_to_filter,
-            title="Protein Intake Reminder",
-            body="Remember to focus on your protein intake today to support muscle repair, especially after your strength session.",
-            message_type="RECOMMENDATION",
-            urgency="MEDIUM",
-            deep_link="/nutrition-log-page",
-            created_at=datetime.datetime.now() - datetime.timedelta(hours=1),
-            read_at=None
-        ),
-        AICoachMessageResponse(
-            id="msg_004",
-            user_id=user_id_to_filter,
-            body="You've hit a new personal best on your squat! Keep up the fantastic work.",
-            message_type="PRAISE",
-            urgency="MEDIUM",
-            created_at=datetime.datetime.now() - datetime.timedelta(days=2, hours=3)
-        ),
-         AICoachMessageResponse(
-            id="msg_005",
-            user_id=user_id_to_filter,
-            title="Upcoming Check-in",
-            body="Don\'t forget your scheduled check-in with your coach tomorrow at 10:00 AM.",
-            message_type="INFO",
-            urgency="MEDIUM",
-            deep_link="/calendar-page", # Assuming a calendar page
-            created_at=datetime.datetime.now() - datetime.timedelta(hours=20)
-        )
-    ]
-    
-    # Simulate filtering by unread or limit
-    # return [msg for msg in mock_messages if msg.read_at is None][:3] 
-    return mock_messages[:3] # Return first 3 for brevity in the dashboard
+    supabase_url = db.secrets.get("SUPABASE_URL")
+    supabase_key = db.secrets.get("SUPABASE_ANON_KEY")
+
+    if not supabase_url or not supabase_key:
+        raise HTTPException(status_code=500, detail="Supabase configuration missing")
+
+    client: Client = create_client(supabase_url, supabase_key)
+
+    try:
+        query = client.table("ai_coach_messages").select("*").eq("user_id", user.sub)
+        if unread_only:
+            query = query.is_("read_at", None)
+        response = query.order("created_at").execute()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Error fetching messages: {exc}") from exc
+
+    records = response.data or []
+    return [AICoachMessageResponse(**record) for record in records]


### PR DESCRIPTION
## Summary
- connect ai-coach-messages API to Supabase
- fetch messages for authenticated user and optionally filter unread

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684528d0ac6c8323afa2b569785a4b70