### PR TITLE
Add test target and doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,8 @@ run-backend:
 run-frontend:
 	cd frontend && ./run.sh
 
+.PHONY: test
+test:
+	pytest
+
 .DEFAULT_GOAL := install

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ make run-backend
 make run-frontend
 ```
 
+## Testing
+
+Run the test suite with:
+
+```bash
+make test
+```
+
 ## Gotchas
 
 The backend server runs on port 8000 and the frontend development server runs on port 5173. The frontend Vite server proxies API requests to the backend on port 8000.


### PR DESCRIPTION
## Summary
- add `make test` to run pytest
- describe the new testing command in the README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684528d6717883238845634bbcad2ff8