### PR TITLE
Remove stray console logs

### DIFF
--- a/frontend/src/app/auth/index.ts
+++ b/frontend/src/app/auth/index.ts
@@ -1,5 +1,7 @@
+import { log } from '../../utils/logger';
+
 const validateConfig = () => {
-  console.log("No auth extension enabled");
+  log('No auth extension enabled');
 };
 
 export const auth = {

--- a/frontend/src/components/NextActivitiesSection.tsx
+++ b/frontend/src/components/NextActivitiesSection.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import StyledContentBox from "./StyledContentBox";
 import { CalendarDays, Brain as BrainIconLucide, Dumbbell, Link as LinkIcon, ChevronRight } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { log } from '../utils/logger';
 
 interface Activity {
   id: string;
@@ -35,7 +36,7 @@ const NextActivitiesSection: React.FC<Props> = ({ nextActivities, isLoadingNextA
       // Default navigation or action if no specific link
       // For example, navigate to a generic activity details page
       // navigate(`/activity/${activity.id}`);
-      console.log("Clicked activity:", activity.title);
+      log("Clicked activity:", activity.title);
     }
   };
 

--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -1,0 +1,11 @@
+export const log = (...args: unknown[]): void => {
+  if (import.meta.env.DEV) {
+    console.log(...args);
+  }
+};
+
+export const error = (...args: unknown[]): void => {
+  if (import.meta.env.DEV) {
+    console.error(...args);
+  }
+};

--- a/frontend/src/utils/supabaseClient.ts
+++ b/frontend/src/utils/supabaseClient.ts
@@ -1,5 +1,6 @@
 
 import { createClient } from '@supabase/supabase-js';
+import { log } from './logger';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
@@ -114,7 +115,7 @@ export const fetchWellnessDataForDashboard = async (userId: string): Promise<Wel
 
 
 export const fetchTrainingDataForDashboard = async (userId: string, referenceDate: Date): Promise<TrainingDashboardData> => {
-  console.log(`Fetching training dashboard data for user ${userId} with reference date ${referenceDate.toISOString()}`);
+  log(`Fetching training dashboard data for user ${userId} with reference date ${referenceDate.toISOString()}`);
   const today = new Date(referenceDate); // Use referenceDate for all calculations
   today.setHours(0, 0, 0, 0); // Normalize to start of day
 
@@ -128,7 +129,7 @@ export const fetchTrainingDataForDashboard = async (userId: string, referenceDat
     weekEndDate.setHours(23,59,59,999);
 
     const weekLabel = `Sem. ${formatDateToYYYYMMDD(weekStartDate).substring(5)} - ${formatDateToYYYYMMDD(weekEndDate).substring(5)}`;
-    console.log(`Processing week: ${weekLabel}, Start: ${weekStartDate.toISOString()}, End: ${weekEndDate.toISOString()}`);
+    log(`Processing week: ${weekLabel}, Start: ${weekStartDate.toISOString()}, End: ${weekEndDate.toISOString()}`);
 
     const { data: sessionsInWeek, error: sessionsError } = await supabase
       .from('registros_sesion_entrenamiento')
@@ -187,14 +188,14 @@ export const fetchTrainingDataForDashboard = async (userId: string, referenceDat
     }
     weeklyVolumeData.push({ weekLabel, totalVolume: Math.round(totalVolumeForWeek), startDate: formatDateToYYYYMMDD(weekStartDate), endDate: formatDateToYYYYMMDD(weekEndDate) });
   }
-  console.log("Weekly Volume Data:", weeklyVolumeData);
+  log("Weekly Volume Data:", weeklyVolumeData);
 
   // 2. Calculate Training Frequency by Muscle Group (Last 30 days)
   const thirtyDaysAgo = new Date(today);
   thirtyDaysAgo.setDate(today.getDate() - 29); // -29 to include today, making it 30 days total
   thirtyDaysAgo.setHours(0,0,0,0);
 
-  console.log(`Fetching muscle group frequency from ${thirtyDaysAgo.toISOString()} to ${today.toISOString()}`);
+  log(`Fetching muscle group frequency from ${thirtyDaysAgo.toISOString()} to ${today.toISOString()}`);
 
   const { data: sessionsForFrequency, error: freqSessionsError } = await supabase
     .from('registros_sesion_entrenamiento')
@@ -236,7 +237,7 @@ export const fetchTrainingDataForDashboard = async (userId: string, referenceDat
     .map(([name, value]) => ({ name, value }))
     .sort((a, b) => b.value - a.value); // Sort by count descending
   
-  console.log("Muscle Group Frequency Data:", muscleGroupFrequencyData);
+  log("Muscle Group Frequency Data:", muscleGroupFrequencyData);
 
   return {
     weeklyVolumeData,

--- a/frontend/src/utils/useAuthStore.ts
+++ b/frontend/src/utils/useAuthStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { supabase } from './supabaseClient'; // Asegúrate que la ruta sea correcta
+import { log } from './logger';
 import type { Session, User } from '@supabase/supabase-js';
 
 interface AuthState {
@@ -65,7 +66,7 @@ const useAuthStore = create<AuthState>((set, get) => ({
 // Esto se ejecuta una vez cuando el store se importa por primera vez.
 supabase.auth.onAuthStateChange((event, session) => {
   const store = useAuthStore.getState();
-  console.log('Supabase auth state change:', event, session);
+  log('Supabase auth state change:', event, session);
   store.setSession(session);
   store.setLoading(false); // Asegurarse de que loading sea false después del cambio
 });


### PR DESCRIPTION
## Summary
- replace direct `console.log` calls with a lightweight logger
- add simple logger utility

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684528d8ee0c83239af26e19fc4ef32b