### PR TITLE
Fix vite alias mapping

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -76,13 +76,9 @@ export default defineConfig({
 			},
 		},
 	},
-	resolve: {
-		alias: {
-			resolve: {
-				alias: {
-					"@": path.resolve(__dirname, "./src"),
-				},
-			},
-		},
-	},
+        resolve: {
+                alias: {
+                        "@": path.resolve(__dirname, "./src"),
+                },
+        },
 });


### PR DESCRIPTION
## Summary
- streamline vite alias config

## Testing
- `npx ts-node --esm -P frontend/tsconfig.json -e "import btn from '@/components/ui/button'; console.log('loaded alias');"`

------
https://chatgpt.com/codex/tasks/task_e_6847ac82ed508323a7a22e99c33fb242