### PR TITLE
Replace prints with logging

### DIFF
--- a/backend/databutton_app/mw/auth_mw.py
+++ b/backend/databutton_app/mw/auth_mw.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 from http import HTTPStatus
 from typing import Annotated, Callable
 import jwt
@@ -7,6 +8,8 @@ from fastapi.requests import HTTPConnection
 from jwt import PyJWKClient
 from pydantic import BaseModel
 from starlette.requests import Request
+
+logger = logging.getLogger(__name__)
 
 
 class AuthConfig(BaseModel):
@@ -61,9 +64,9 @@ def get_authorized_user(
 
         if user is not None:
             return user
-        print("Request authentication returned no user")
+        logger.warning("Request authentication returned no user")
     except Exception as e:
-        print(f"Request authentication failed: {e}")
+        logger.exception("Request authentication failed: %s", e)
 
     if isinstance(request, WebSocket):
         raise WebSocketException(
@@ -111,7 +114,7 @@ def authorize_websocket(
             break
 
     if not token:
-        print(f"Missing bearer {prefix}.<token> in protocols")
+        logger.warning("Missing bearer %s.<token> in protocols", prefix)
         return None
 
     return authorize_token(token, auth_config)
@@ -123,12 +126,12 @@ def authorize_request(
 ) -> User | None:
     auth_header = request.headers.get(auth_config.header)
     if not auth_header:
-        print(f"Missing header '{auth_config.header}'")
+        logger.warning("Missing header '%s'", auth_config.header)
         return None
 
     token = auth_header.startswith("Bearer ") and auth_header[7:]
     if not token:
-        print(f"Missing bearer token in '{auth_config.header}'")
+        logger.warning("Missing bearer token in '%s'", auth_config.header)
         return None
 
     return authorize_token(token, auth_config)
@@ -146,7 +149,7 @@ def authorize_token(
         try:
             key, alg = get_signing_key(jwks_url, token)
         except Exception as e:
-            print(f"Failed to get signing key {e}")
+            logger.error("Failed to get signing key %s", e)
             continue
 
         try:
@@ -157,13 +160,13 @@ def authorize_token(
                 audience=audience,
             )
         except jwt.PyJWTError as e:
-            print(f"Failed to decode and validate token {e}")
+            logger.error("Failed to decode and validate token %s", e)
             continue
 
     try:
         user = User.model_validate(payload)
-        print(f"User {user.sub} authenticated")
+        logger.debug("User %s authenticated", user.sub)
         return user
     except Exception as e:
-        print(f"Failed to parse token payload {e}")
+        logger.error("Failed to parse token payload %s", e)
         return None


### PR DESCRIPTION
## Summary
- configure global log level via the `LOG_LEVEL` env var
- switch print statements to logging in `auth_mw.py` and `health_data` API
- sanitize secrets and token info in API logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847bc10021083238f8867d5653ee187