### PR TITLE
Fix stray backslash in health_data API

### DIFF
--- a/backend/app/apis/health_data/__init__.py
+++ b/backend/app/apis/health_data/__init__.py
@@ -1,4 +1,3 @@
-\
 # Standard library imports
 from typing import List, Optional, Dict, Any
 


### PR DESCRIPTION
## Summary
- clean up stray backslash at the beginning of `backend/app/apis/health_data/__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c2c1647c8323a9368895cf92923b