### PR TITLE
Add python-dotenv dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,4 +7,5 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115.8",
     "uvicorn>=0.34.0",
+    "python-dotenv",
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ openai
 beautifulsoup4
 requests
 supabase
+python-dotenv


### PR DESCRIPTION
## Summary
- add `python-dotenv` to backend requirements
- list `python-dotenv` in backend `pyproject.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6847c2b2a27c8323acbc00333570ef06