### PR TITLE
Improve tablet responsive design

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ The backend server runs on port 8000 and the frontend development server runs on
 
 Visit <http://localhost:5173> to view the application.
 
+## Mobile Optimization
+
+The UI now includes custom breakpoints targeting iPad devices. Layouts adapt to a
+three-column grid on screens wider than 834&nbsp;px and fonts scale up slightly
+for tablet viewing.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -108,3 +108,9 @@
   animation: line-flow 2s linear infinite;
   background-size: 200% 100%; /* Important for gradient movement */
 }
+
+@media (min-width: 834px) and (max-width: 1024px) {
+  html {
+    font-size: 17px;
+  }
+}

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -240,7 +240,7 @@ export default function App() {
             Cada herramienta y característica de NGX Pulse está diseñada para ofrecerte una visión 360º de tu progreso y potenciar tu camino hacia la excelencia.
           </SectionSubtitle>
           
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8">
+          <div className="grid sm:grid-cols-2 ipad:grid-cols-3 gap-6 lg:gap-8">
             {features.slice(0,6).map((feature, index) => (
               <div
                 key={index}
@@ -276,7 +276,7 @@ export default function App() {
               Accede directamente a tus registros y herramientas de seguimiento.
             </p>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 lg:gap-8">
+          <div className="grid grid-cols-1 sm:grid-cols-2 ipad:grid-cols-3 lg:grid-cols-4 gap-6 lg:gap-8">
             {[ // Navigation items
               {
                 title: "Bienestar y Movilidad",

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,6 +4,9 @@ export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
+      screens: {
+        ipad: '834px',
+      },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",


### PR DESCRIPTION
## Summary
- add custom `ipad` screen to Tailwind theme
- update home page feature grids to use the tablet layout
- tweak base font size for iPad via CSS
- document the new mobile optimization

## Testing
- `pytest -q tests/test_main.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6847cd1add80832382c08c69a0a5db14