### PR TITLE
Fix stray backslash in health data init

### DIFF
--- a/backend/app/apis/health_data/__init__.py
+++ b/backend/app/apis/health_data/__init__.py
@@ -1,4 +1,3 @@
-\
 # Standard library imports
 from typing import List, Optional, Dict, Any
 


### PR DESCRIPTION
## Summary
- remove an accidental `\` line in `backend/app/apis/health_data/__init__.py`

## Testing
- `git show --stat --oneline -1`

------
https://chatgpt.com/codex/tasks/task_e_6847d20dfaf88323809d5fae275bade9