### PR TITLE
Add python-dotenv dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,4 +7,5 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115.8",
     "uvicorn>=0.34.0",
+    "python-dotenv>=1.0",
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ openai
 beautifulsoup4
 requests
 supabase
+python-dotenv==1.1.0


### PR DESCRIPTION
## Summary
- ensure python-dotenv is included in backend dependencies
- add python-dotenv to requirements file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d20ef3248323a68164ea0f1dd2b8