### PR TITLE
feat(auth): centralize JWT/Supabase auth dependency

### DIFF
--- a/backend/app/apis/ai_coach_messages_api/__init__.py
+++ b/backend/app/apis/ai_coach_messages_api/__init__.py
@@ -32,7 +32,7 @@ class AICoachMessageResponse(BaseModel):
 @router.get("/", response_model=List[AICoachMessageResponse])
 def get_ai_coach_messages(
     unread_only: bool = False,
-    user: AuthorizedUser = None,
+    user: AuthorizedUser = Depends(),
 ) -> List[AICoachMessageResponse]:
     """Return AI Coach messages for the authenticated user."""
 

--- a/backend/app/auth/user.py
+++ b/backend/app/auth/user.py
@@ -9,11 +9,4 @@ Usage:
         return example_read_data_for_user(userId=user.sub)
 """
 
-from typing import Annotated
-
-from fastapi import Depends
-
-from databutton_app.mw.auth_mw import get_authorized_user, User
-
-
-AuthorizedUser = Annotated[User, Depends(get_authorized_user)]
+from app.utils.auth import AuthorizedUser, User

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for shared backend helpers."""

--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -1,0 +1,196 @@
+import functools
+import logging
+import os
+from http import HTTPStatus
+from typing import Any, Annotated
+
+import jwt
+from fastapi import Depends, HTTPException, WebSocket, WebSocketException, status
+from fastapi.requests import HTTPConnection
+from jwt import PyJWKClient
+from pydantic import BaseModel, Field
+from starlette.requests import Request
+
+from app.demo_data import is_demo_mode
+
+logger = logging.getLogger(__name__)
+
+
+class AuthConfig(BaseModel):
+    jwks_url: str
+    audience: str
+    header: str = "authorization"
+
+
+class User(BaseModel):
+    sub: str
+    email: str | None = None
+    name: str | None = None
+    role: str | None = None
+    raw_claims: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def user_id(self) -> str:
+        return self.sub
+
+
+def get_auth_config(request: HTTPConnection) -> AuthConfig | None:
+    return getattr(request.app.state, "auth_config", None)
+
+
+AuthConfigDep = Annotated[AuthConfig | None, Depends(get_auth_config)]
+
+
+def _demo_user() -> User:
+    return User(
+        sub="demo-user-1",
+        email="demo.user@nexus.pulse",
+        name="Demo User",
+        role="demo",
+        raw_claims={},
+    )
+
+
+def _build_supabase_config() -> AuthConfig | None:
+    supabase_url = os.getenv("SUPABASE_URL")
+    if not supabase_url:
+        return None
+    jwks_url = f"{supabase_url.rstrip('/')}/auth/v1/.well-known/jwks.json"
+    audience = os.getenv("SUPABASE_JWT_AUDIENCE", "authenticated")
+    return AuthConfig(jwks_url=jwks_url, audience=audience, header="authorization")
+
+
+@functools.cache
+def _get_jwks_client(url: str) -> PyJWKClient:
+    return PyJWKClient(url, cache_keys=True)
+
+
+def _get_signing_key(url: str, token: str) -> tuple[str, str]:
+    client = _get_jwks_client(url)
+    signing_key = client.get_signing_key_from_jwt(token)
+    key = signing_key.key
+    alg = signing_key.algorithm_name
+    if alg != "RS256":
+        raise ValueError(f"Unsupported signing algorithm: {alg}")
+    return key, alg
+
+
+def _token_from_websocket(request: WebSocket) -> str | None:
+    header = "Sec-Websocket-Protocol"
+    sep = ","
+    prefix = "Authorization.Bearer."
+    protocols_header = request.headers.get(header)
+    protocols = (
+        [h.strip() for h in protocols_header.split(sep)] if protocols_header else []
+    )
+    for protocol in protocols:
+        if protocol.startswith(prefix):
+            return protocol.removeprefix(prefix)
+    return None
+
+
+def _token_from_request(request: Request, header: str) -> str | None:
+    auth_header = request.headers.get(header)
+    if not auth_header:
+        return None
+    scheme, _, token = auth_header.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        return None
+    return token
+
+
+def _extract_token(request: HTTPConnection, header: str) -> str | None:
+    if isinstance(request, WebSocket):
+        return _token_from_websocket(request)
+    if isinstance(request, Request):
+        return _token_from_request(request, header)
+    return None
+
+
+def _build_user_from_claims(claims: dict[str, Any]) -> User:
+    if not claims or "sub" not in claims:
+        raise ValueError("Token payload missing subject")
+    metadata = claims.get("user_metadata") or {}
+    return User(
+        sub=claims["sub"],
+        email=claims.get("email"),
+        name=claims.get("name") or metadata.get("full_name") or metadata.get("name"),
+        role=claims.get("role"),
+        raw_claims=claims,
+    )
+
+
+def _decode_with_jwks(token: str, config: AuthConfig) -> dict[str, Any]:
+    key, alg = _get_signing_key(config.jwks_url, token)
+    issuer = os.getenv("SUPABASE_JWT_ISSUER")
+    options: dict[str, Any] = {}
+    return jwt.decode(
+        token,
+        key=key,
+        algorithms=[alg],
+        audience=config.audience,
+        issuer=issuer,
+        options=options,
+    )
+
+
+def _decode_with_secret(token: str, secret: str) -> dict[str, Any]:
+    audience = os.getenv("JWT_AUDIENCE")
+    issuer = os.getenv("JWT_ISSUER")
+    return jwt.decode(
+        token,
+        key=secret,
+        algorithms=[os.getenv("JWT_ALGORITHM", "HS256")],
+        audience=audience,
+        issuer=issuer,
+    )
+
+
+def get_authorized_user(request: HTTPConnection, config: AuthConfigDep = None) -> User:
+    if is_demo_mode():
+        return _demo_user()
+
+    supabase_config = _build_supabase_config()
+    secret = os.getenv("JWT_SECRET_KEY")
+
+    active_configs = [cfg for cfg in [config, supabase_config] if cfg is not None]
+
+    if not active_configs and not secret:
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Auth configuration missing",
+        )
+
+    header = active_configs[0].header if active_configs else "authorization"
+    token = _extract_token(request, header)
+    if not token:
+        if isinstance(request, WebSocket):
+            raise WebSocketException(
+                code=status.WS_1008_POLICY_VIOLATION, reason="Not authenticated"
+            )
+        raise HTTPException(
+            status_code=HTTPStatus.UNAUTHORIZED, detail="Not authenticated"
+        )
+
+    for cfg in active_configs:
+        try:
+            claims = _decode_with_jwks(token, cfg)
+            return _build_user_from_claims(claims)
+        except Exception as exc:
+            logger.debug("JWKS auth failed: %s", exc)
+
+    if secret:
+        try:
+            claims = _decode_with_secret(token, secret)
+            return _build_user_from_claims(claims)
+        except Exception as exc:
+            logger.debug("JWT secret auth failed: %s", exc)
+
+    if isinstance(request, WebSocket):
+        raise WebSocketException(
+            code=status.WS_1008_POLICY_VIOLATION, reason="Not authenticated"
+        )
+    raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Not authenticated")
+
+
+AuthorizedUser = Annotated[User, Depends(get_authorized_user)]

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,7 +23,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-from databutton_app.mw.auth_mw import AuthConfig, get_authorized_user
+from app.utils.auth import AuthConfig, get_authorized_user
 
 
 def get_router_config() -> dict:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ supabase>=2.0.0
 python-dotenv==1.1.0
 pydantic>=2.0.0
 typing-extensions>=4.0.0
+PyJWT>=2.8.0

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,44 @@
+import importlib.util
+from pathlib import Path
+
+import jwt
+from fastapi.testclient import TestClient
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "backend" / "main.py"
+spec = importlib.util.spec_from_file_location("backend_main", MODULE_PATH)
+backend_main = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(backend_main)
+
+
+def _build_client(monkeypatch: object) -> TestClient:
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret")
+    monkeypatch.setenv("STAGING_DEMO_MODE", "true")
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_ANON_KEY", raising=False)
+    return TestClient(backend_main.create_app())
+
+
+def test_protected_endpoint_rejects_missing_token(monkeypatch):
+    client = _build_client(monkeypatch)
+
+    response = client.get("/routes/ai-coach-messages/")
+
+    assert response.status_code == 401
+
+
+def test_protected_endpoint_accepts_valid_token(monkeypatch):
+    client = _build_client(monkeypatch)
+    token = jwt.encode(
+        {"sub": "user-123", "email": "user@example.com", "role": "authenticated"},
+        "test-secret",
+        algorithm="HS256",
+    )
+
+    response = client.get(
+        "/routes/ai-coach-messages/",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,20 +1,7 @@
 import json
 import importlib.util
 from pathlib import Path
-import sys
-import types
-
 import pytest
-
-# Provide stub for databutton_app dependency so main.py can be imported
-sys.modules["databutton_app"] = types.ModuleType("databutton_app")
-sys.modules["databutton_app.mw"] = types.ModuleType("databutton_app.mw")
-stub = types.ModuleType("databutton_app.mw.auth_mw")
-stub.AuthConfig = object
-def _dummy():
-    pass
-stub.get_authorized_user = _dummy
-sys.modules["databutton_app.mw.auth_mw"] = stub
 
 # Dynamically import backend/main.py as module 'backend_main'
 MODULE_PATH = Path(__file__).resolve().parents[1] / "backend" / "main.py"
@@ -57,4 +44,3 @@ def test_is_auth_disabled_missing():
 def test_is_auth_disabled_valid():
     cfg = {"routers": {"api": {"disableAuth": True}}}
     assert backend_main.is_auth_disabled(cfg, "api") is True
-


### PR DESCRIPTION
### Motivation
- Replace the placeholder `get_authorized_user` with a real, centralized auth implementation to support JWT and Supabase JWKS flows.
- Provide a single `AuthorizedUser` FastAPI dependency so endpoints can consistently require authentication via `Depends`.
- Reduce duplicated auth logic in per-router modules (e.g. health and AI coach) and support demo-mode bypass for staging.
- Add unit tests that exercise protected endpoints for success and failure cases so auth behavior is verifiable.

### Description
- Added a centralized auth module at `backend/app/utils/auth.py` that implements `AuthConfig`, `User`, JWKS (`PyJWKClient`) verification, secret-based JWT verification, WebSocket token parsing, and a `get_authorized_user` dependency exported as `AuthorizedUser`.
- Updated `backend/main.py` and `backend/app/auth/user.py` to import the new auth utilities (`AuthConfig`, `get_authorized_user`, `AuthorizedUser`).
- Rewired protected endpoints to use the new dependency: `backend/app/apis/health_data/__init__.py` and `backend/app/apis/ai_coach_messages_api/__init__.py` now declare the authenticated user with `AuthorizedUser = Depends()` and use `user.sub` for the subject.
- Added tests (`tests/test_auth.py`) to validate protected endpoint rejection and acceptance, adjusted `tests/test_main.py` to use the new setup, and added `PyJWT>=2.8.0` to `backend/requirements.txt`.

### Testing
- Ran `pytest tests/test_auth.py tests/test_main.py` in the current environment; collection failed due to missing runtime packages (`ModuleNotFoundError: No module named 'jwt'` and `No module named 'dotenv'`).
- The failures are environmental (missing dependencies) rather than code logic; `PyJWT` was added to `backend/requirements.txt` to address the `jwt` import and `python-dotenv` is already declared but must be installed in the test environment.
- After installing backend dependencies (e.g. `pip install -r backend/requirements.txt`) the added tests should run and verify that protected routes return `401` for missing tokens and `200` for a valid HS256 token signed with `JWT_SECRET_KEY`.
- No other automated tests were modified; existing `tests/test_main.py` tests that validate router config and `is_auth_disabled` remain present and should continue to pass once dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962815f7f988323b9bf25b77b2908bb)