### PR TITLE
feat(frontend): AI endpoint timeout fallback + demo-mode status doc

### DIFF
--- a/docs/demo-mode-status.md
+++ b/docs/demo-mode-status.md
@@ -1,0 +1,34 @@
+# Estado de demo vs. datos reales (frontend)
+
+## Módulos con mocks en `frontend/src/`
+
+- `frontend/src/utils/demoClient.ts`
+  - Cliente de autenticación demo (offline). Actualmente **no está referenciado** por otros módulos de frontend; queda como alternativa de desarrollo.
+- `frontend/src/utils/demoAIService.ts`
+  - Mock de IA para endpoints `/api/ai/*`.
+  - Usado como fallback automático desde `frontend/src/utils/apiClient.ts` cuando el backend no responde.
+- `frontend/src/components/NotificationsTab.tsx`
+  - Datos simulados en memoria (`mockNotifications`) para la lista de notificaciones.
+
+## Vistas con datos reales (backend/Supabase)
+
+- **Login/Sign Up** (`frontend/src/pages/AuthPage.tsx`, `frontend/src/pages/SignUpPage.tsx`):
+  - Autenticación real vía Supabase (`supabase.auth`).
+- **Dashboard** (`frontend/src/pages/DashboardPage.tsx`):
+  - Métricas biométricas, tendencias y sparklines reales vía Supabase.
+  - Mensajes del AI Coach vía `apiClient` (backend), con fallback a mock si el backend no responde.
+- **Logging pages** (datos reales vía Supabase):
+  - `frontend/src/pages/BiometricLogPage.tsx`
+  - `frontend/src/pages/TrainingLogPage.tsx`
+  - `frontend/src/pages/NutritionLogPage.tsx`
+  - `frontend/src/pages/WellnessLogPage.tsx`
+  - `frontend/src/pages/DailyCheckinPage.tsx`
+
+## Vistas en modo demo o parcial (con fallback)
+
+- **Program Wizard** (`frontend/src/components/ProgramWizard.tsx`):
+  - Usa `/api/ai/generate-program` vía `apiClient`, con fallback automático a mock si el backend no responde.
+- **Mensajes del AI Coach** en el Dashboard:
+  - `/api/ai/coach-messages` vía `apiClient`, con fallback automático a mock si el backend no responde.
+- **Notificaciones** (`frontend/src/components/NotificationsTab.tsx`):
+  - Persisten en modo demo con `mockNotifications` hasta que exista endpoint real.

--- a/frontend/src/utils/demoAIService.ts
+++ b/frontend/src/utils/demoAIService.ts
@@ -38,6 +38,18 @@ interface AIGeneratedProgram {
   ai_rationale: string;
 }
 
+interface AICoachMessage {
+  id: string;
+  user_id: string;
+  title?: string | null;
+  body: string;
+  message_type: 'ALERT' | 'INFO' | 'RECOMMENDATION' | 'PRAISE' | 'MOTIVATION' | 'WARNING' | 'ERROR';
+  urgency: 'LOW' | 'MEDIUM' | 'HIGH';
+  deep_link?: string | null;
+  created_at: string;
+  read_at?: string | null;
+}
+
 // Program name generators
 const FITNESS_PROGRAM_NAMES = [
   "Transformación Elite",
@@ -198,6 +210,42 @@ const generateWeeklyStructure = (
   }
   
   return structure;
+};
+
+const generateCoachMessages = (): AICoachMessage[] => {
+  const now = Date.now();
+
+  const templates = [
+    {
+      title: 'Recuperación priorizada',
+      body: 'Tu HRV ha bajado ligeramente. Considera una sesión de movilidad suave hoy.',
+      message_type: 'RECOMMENDATION' as const,
+      urgency: 'MEDIUM' as const,
+      deep_link: '/wellness-log-page'
+    },
+    {
+      title: 'Objetivo semanal en marcha',
+      body: 'Llevas 3 sesiones registradas esta semana. Te falta 1 para alcanzar tu meta.',
+      message_type: 'MOTIVATION' as const,
+      urgency: 'LOW' as const,
+      deep_link: '/training-log-page'
+    },
+    {
+      title: 'Nutrición consistente',
+      body: 'Buen trabajo manteniendo tu ingesta de proteína durante los últimos días.',
+      message_type: 'PRAISE' as const,
+      urgency: 'LOW' as const,
+      deep_link: '/nutrition-log-page'
+    }
+  ];
+
+  return templates.map((template, index) => ({
+    id: `demo-coach-${index + 1}`,
+    user_id: 'demo-user',
+    created_at: new Date(now - index * 2 * 60 * 60 * 1000).toISOString(),
+    read_at: index === 2 ? new Date(now - index * 2 * 60 * 60 * 1000 + 20 * 60 * 1000).toISOString() : null,
+    ...template
+  }));
 };
 
 const generateSuccessMetrics = (goals: ProgramGoal[], preferences: Record<string, string>, programType: 'fitness' | 'nutrition'): string[] => {
@@ -367,6 +415,10 @@ export const mockAIAPICall = async (endpoint: string, data: any): Promise<{ succ
     if (endpoint === '/api/ai/generate-program') {
       const result = await generateProgramWithAI(data);
       return { success: true, data: result };
+    }
+
+    if (endpoint === '/api/ai/coach-messages') {
+      return { success: true, data: generateCoachMessages() };
     }
     
     throw new Error('Unknown endpoint');


### PR DESCRIPTION
### Motivation

- Provide a gradual migration from in-repo mocks to real backend calls while keeping a safe fallback when AI backend endpoints are unavailable.
- Ensure critical UI flows (program generation, AI coach messages) attempt the real API first and remain usable if the backend times out or fails.
- Surface which frontend views are still in demo mode so engineers and QA know where real data is expected.

### Description

- Added a timeout-backed AI request pipeline in `frontend/src/utils/apiClient.ts` including `aiTimeoutMs`, `fetchWithTimeout`, `requestAiEndpoint` and `fallbackToMock` and routed `/api/ai/*` `GET`/`POST` calls through it.
- Updated `post`/`get` logic in `apiClient` to use the new AI handler so AI endpoints attempt the backend first and then fall back to `mockAIAPICall` on timeout or error.
- Extended `frontend/src/utils/demoAIService.ts` with an `AICoachMessage` type, `generateCoachMessages` and support for the `/api/ai/coach-messages` mock endpoint so the dashboard and notifications have deterministic demo data.
- Added `docs/demo-mode-status.md` documenting which frontend modules and pages use real Supabase/backend data versus demo/mock fallbacks.

### Testing

- No automated tests were executed as part of this change.
- Unit or integration test updates for the new AI request flow were not included in this PR.
- Static checks (`yarn lint`, `yarn type-check`) were not run as part of the rollout.
- Manual smoke testing is recommended for `ProgramWizard` and Dashboard AI messages after deployment to verify fallback behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69628167415c8323bca4ea65d29ad9d4)