### PR TITLE
feat: add Dockerfiles, docker-compose, README docker quick-start, and Makefile checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ lint-frontend:
 type-check:
 	cd frontend && npm run type-check
 
+lint: lint-frontend
+
+check: lint type-check test
+
 seed-demo:
 	@echo "🌱 Seeding demo data for NGX Pulse..."
 	@if [ ! -f backend/.env ]; then \
@@ -62,7 +66,7 @@ seed-demo-clean:
 	@echo "🧹 Cleaning and re-seeding demo data..."
 	cd scripts && python seed-demo-data.py --days 30 --clean
 
-.PHONY: test build check-env lint-frontend type-check seed-demo seed-demo-clean
+.PHONY: test build check-env lint-frontend type-check lint check seed-demo seed-demo-clean
 test:
 	pytest
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ cp frontend/.env.example frontend/.env
 # - Other service credentials
 ```
 
+#### ✅ Minimal Environment Variables
+Backend (`backend/.env`):
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY` (required for service operations)
+
+Frontend (`frontend/.env`):
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+- `VITE_API_BASE_URL` (defaults to `http://localhost:8000` for local dev)
+
 ### **3. Start Development Servers**
 ```bash
 # Start backend (Terminal 1)
@@ -132,6 +143,22 @@ make run-frontend
 - **Frontend**: http://localhost:5173
 - **Backend API**: http://localhost:8000/docs
 - **Database**: Configure with your Supabase credentials
+
+---
+
+## 🐳 **Docker Quick Start (Clean Boot)**
+
+```bash
+# Create env files from templates if needed
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+
+# Start everything with a single command
+docker compose up --build
+```
+
+- Frontend: http://localhost:5173
+- Backend: http://localhost:8000/docs
 
 ---
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN python -m pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ./backend
+    env_file:
+      - ./backend/.env
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build:
+      context: ./frontend
+    env_file:
+      - ./frontend/.env
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]


### PR DESCRIPTION
### Motivation
- Provide a minimal containerized development flow so frontend and backend can be started with a single command.
- Document the minimal environment variables required for local development to avoid missing-config issues.
- Add lightweight Makefile checks to make it easier to run linting, type-checks and tests during development.

### Description
- Added `backend/Dockerfile`, `frontend/Dockerfile`, and a root `docker-compose.yml` to build and run both services together.
- Documented minimal environment variables and a `docker compose up --build` quick-start in `README.md` and included instructions to copy `.env.example` files.
- Added `lint` and `check` targets to the `Makefile` and updated `.PHONY` to include the new targets so `make check` runs `lint`, `type-check`, and `test`.

### Testing
- Attempted to run `docker compose up --build --detach` to validate the clean boot, but it failed because Docker is not available in the current environment.
- No other automated test commands were executed in this environment; the `Makefile` now exposes `test` (`pytest`) for local CI runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962816a57a48323bbf12785a8743a3a)